### PR TITLE
no username fixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,10 +18,11 @@ WriteMakefile(
 	MIN_PERL_VERSION => 5.008006,
 
 	PREREQ_PM      => {
-		XML::Simple => '2.13',
-		LWP         => '5.805',
-		JSON        => '1.14',
-		Test::More  => '0.94',
+		XML::Simple =    > '2.13',
+		LWP             => '5.805',
+		JSON            => '1.14',
+		Test::More      => '0.94',
+    Test::Exception => '0.31',
 		},
 
 	META_MERGE     => {
@@ -32,6 +33,7 @@ WriteMakefile(
 			},
 		test_requires => {
 			Test::More => '0.94',
+      Test::Exception => '0.31',
 			},
 		resources => {
 			repository => 'git@github.com:briandfoy/geo-geonames.git',

--- a/lib/Geo/GeoNames.pm
+++ b/lib/Geo/GeoNames.pm
@@ -261,19 +261,23 @@ sub _parse_xml_result {
 	foreach my $element (keys %{$xml}) {
 		if ($element eq 'status') {
 			carp "ERROR: " . $xml->{$element}->[0]->{message};
-			}
-		next if (ref($xml->{$element}) ne "ARRAY");
-		foreach my $list (@{$xml->{$element}}) {
-			next if (ref($list) ne "HASH");
-			foreach my $attribute (%{$list}) {
-				next if !defined($list->{$attribute}->[0]);
-				$result[$i]->{$attribute} = $list->{$attribute}->[0];
-				}
-			$i++;
-			}
-		}
+      $result[$i]->{$element} = $xml->{$element}->[0];
+    }
+    else {
+      next if (ref($xml->{$element}) ne "ARRAY");
+      foreach my $list (@{$xml->{$element}}) {
+        next if (ref($list) ne "HASH");
+        foreach my $attribute (keys %{$list}) {
+          next unless ref($list->{$attribute}) eq 'ARRAY';
+          next if !defined($list->{$attribute}->[0]);
+          $result[$i]->{$attribute} = $list->{$attribute}->[0];
+        }
+        $i++;
+      }
+    }
+  }
 	return \@result;
-	}
+}
 
 sub _parse_json_result {
 	require JSON;

--- a/t/Geo-GeoNames.t
+++ b/t/Geo-GeoNames.t
@@ -18,7 +18,6 @@ subtest 'Make object' => sub {
 	can_ok( $class, 'new' );
 	$geo = Geo::GeoNames->new( username => $ENV{GEONAMES_USER} );
 	isa_ok( $geo, $class );
-  use Data::Dumper;
 	dies_ok( sub { my $bad_geo = Geo::GeoNames->new() }, 'no username passed' );
 };
 


### PR DESCRIPTION
brian d foy, I got your alert that the API for GeoCodes had changed and I went ahead and installed it.  Needless to say, my code didn't do well trying to use the new module without passing a username.  I added a test to prove that the module croaks properly:

dies_ok( sub { my $bad_geo = Geo::GeoNames->new() }, 'no username passed' );

More importantly, I added a subtest called 'valid username' which tests 

subtest 'valid_username' => sub {
  my $browser = LWP::UserAgent->new;
  $browser->env_proxy();
  my $request = $geo->url . '/' . 'postalCodeCountryInfo?username=' . $geo->username;
  my $response = $browser->get($request);
  my $result = $geo->_parse_xml_result($response->content);
  ok(! defined $result->[0]->{status}, 'valid_username');
};

to make sure the module doesn't go crazy when given a bad username.  _parse_xml_result was missing keys in 

foreach my $attribute (keys %{$list}) {

It also died a miserable death here:

next if !defined($list->{$attribute}->[0]);

if there was a status message printing because of username issues.  I added:

    if ($element eq 'status') {
      carp "ERROR: " . $xml->{$element}->[0]->{message};
      $result[$i]->{$element} = $xml->{$element}->[0];
    }
    else {

I hope it is ok that the status message now returns parsed xml.  It didn't before.  Seems ok.

I'd be up for maintaining this code, since I use it in an iOS app API I wrote and it's caused me issues in the past when the API changes, so I'd be on top of it for my own personal reasons.

I've never used git or github before so please forgive me if I'm doing it wrong.

Thanks,

mb
