### PR TITLE
`lang` and `cities` are valid parameters for `find_nearby_placename` …

### DIFF
--- a/lib/Geo/GeoNames.pm
+++ b/lib/Geo/GeoNames.pm
@@ -99,6 +99,8 @@ our %valid_parameters = (
 		radius    => 'o',
 		style    => 'o',
 		maxRows    => 'o',
+        lang => 'o',
+        cities => 'o',
 		username => 'r',
 		},
 	find_nearest_address => {
@@ -813,8 +815,6 @@ B<geonamesId> must be supplied to this function. B<lang> and B<style> are option
 
 For a thorough description of the arguments, see
 http://www.geonames.org/export
-
-=back
 
 =item hiearchy(arg => $arg)
 


### PR DESCRIPTION
…(see http://www.geonames.org/export/web-services.html). Removed a superfluous `=back` in the POD documentation.